### PR TITLE
Update Node version to LTS 18.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.14.1
+FROM node:18.16
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer


### PR DESCRIPTION
Node 14 is EOL 30th of April 2023. This updates references to Node images < 14 to the LTS

[_Created by Sourcegraph batch change `rvu/node-14-eol`._](https://rvu.sourcegraph.com/organizations/rvu/batch-changes/node-14-eol)